### PR TITLE
set default value to 70% as documented

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,12 +24,12 @@
 </head>
 
 <body>
-    <div id="root">
+    <div class="js-root">
         <h1>Upload an image and see the result</h1>
-        <input id="img-input" type="file" accept="image/*" style="display:block" />
+        <input name="img-input" type="file" accept="image/*" style="display:block" />
         <p>image quality is set to 70% by default. You can customize it if you wish</p>
         <p>Image Quality</p>
-        <select name="pets" id="image-quality">
+        <select name="image-quality">
             <option value="">--Please choose an option--</option>
             <option value="0.1">10%</option>
             <option value="0.2">20%</option>
@@ -42,7 +42,7 @@
             <option value="0.9">90%</option>
             <option value="1.0">100%</option>
         </select>
-        <div id="images-container"></div>
+        <div class="js-images-container"></div>
     </div>
     <script src="js/index.js"></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
             <option value="0.4">40%</option>
             <option value="0.5">50%</option>
             <option value="0.6">60%</option>
-            <option value="0.7">70%</option>
+            <option value="0.7" selected>70%</option>
             <option value="0.8">80%</option>
             <option value="0.9">90%</option>
             <option value="1.0">100%</option>

--- a/js/index.js
+++ b/js/index.js
@@ -96,7 +96,7 @@ input.onchange = (event) => {
         displayInfo("Original file", file);
         displayInfo("Compressed file", blob);
         // add a button with a download feature here
-        displayDownloadLink("Dowload Minified Image", blob);
+        displayDownloadLink("Download Minified Image", blob);
         insertBreak();
       },
       MIME_TYPE,

--- a/js/index.js
+++ b/js/index.js
@@ -5,7 +5,7 @@ function $(sel, el) {
 const MAX_WIDTH = 320;
 const MAX_HEIGHT = 180;
 const MIME_TYPE = "image/jpeg";
-let quality = $('select[name="image-quality"]').value;
+let quality = parseFloat($('select[name="image-quality"]').value, 10);
 
 const input = $('input[name="img-input"]');
 const qualitySelector = $('select[name="image-quality"]');
@@ -58,7 +58,7 @@ const insertBreak = () => {
 
 qualitySelector.onchange = (event) => {
   event.preventDefault();
-  quality = parseInt(event.target.value, 10);
+  quality = parseFloat(event.target.value, 10);
 }
 
 input.onchange = (event) => {

--- a/js/index.js
+++ b/js/index.js
@@ -1,10 +1,14 @@
+function $(sel, el) {
+  return (el || document.body).querySelector(sel);
+}
+
 const MAX_WIDTH = 320;
 const MAX_HEIGHT = 180;
 const MIME_TYPE = "image/jpeg";
-let quality = 0.7;
+let quality = $('select[name="image-quality"]').value;
 
-const input = document.getElementById("img-input");
-const qualitySelector = document.getElementById("image-quality");
+const input = $('input[name="img-input"]');
+const qualitySelector = $('select[name="image-quality"]');
 
 const calculateSize = (img, maxWidth, maxHeight) => {
   let width = img.width;
@@ -28,7 +32,7 @@ const calculateSize = (img, maxWidth, maxHeight) => {
 const displayInfo = (label, file) => {
   const p = document.createElement("p");
   p.innerText = `${label} - ${readableBytes(file.size)}`;
-  document.getElementById("images-container").append(p);
+  $(".js-images-container").append(p);
 }
 
 const displayDownloadLink = (linkText, blobData) => {
@@ -37,7 +41,7 @@ const displayDownloadLink = (linkText, blobData) => {
   let url = URL.createObjectURL(blobData);
   downloadLink.href = url;
   downloadLink.download = url;
-  document.getElementById("images-container").append(downloadLink)
+  $(".js-images-container").append(downloadLink)
 }
 
 const readableBytes = (bytes) => {
@@ -49,12 +53,12 @@ const readableBytes = (bytes) => {
 
 const insertBreak = () => {
   let breakElement = document.createElement("br");
-  document.getElementById("images-container").append(breakElement)
+  $(".js-images-container").append(breakElement)
 }
 
 qualitySelector.onchange = (event) => {
   event.preventDefault();
-  quality = Number(event.target.value);
+  quality = parseInt(event.target.value, 10);
 }
 
 input.onchange = (event) => {
@@ -98,7 +102,7 @@ input.onchange = (event) => {
       MIME_TYPE,
       quality
     );
-    document.getElementById("images-container").append(canvas);
+    $(".js-images-container").append(canvas);
     input.value = "";
   };
 };


### PR DESCRIPTION
Can be previewed at https://coolaj86.github.io/img-compressor/

ProTip™: Don't ever use `id` (it pollutes the global namespace and can have other unintended side effects), and always use `querySelector` or `querySelectorAll`, not the 90s-style `getElementByX`.

(and if for some reason you must use `id`, use a `-` or `js-` prefix so that it is unlikely to cause side-effects)

Classe that are not for CSS should have some sort of prefix. I like to use `js-` because it's clear that the class is being used by JavaScript as a DOM selector, not a CSS selector.

Also, `Number` shouldn't be used for casting because it will produce numbers for non-numbers, such as `Number('true')` and some other stuff I can't remember. The downside to `parseFloat` is that it will ignore trailing characters: `parseFloat('10 apples', 10)` (works when it shouldn't), and it can't parse `BigInt` (but `BigInt(str)` can).