### PR TITLE
...one weird trick to make your previews awesome

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # img-compressor
+
 ## Visual Preview:
-![Screen Shot 2021-08-03 at 10 07 32 AM](https://user-images.githubusercontent.com/59545347/128049202-fdd104d8-d855-4319-baec-8beb14d7b6e7.png)
+
+<a href="https://maxsultan.github.io/img-compressor/"><kbd><img src="https://user-images.githubusercontent.com/59545347/128049202-fdd104d8-d855-4319-baec-8beb14d7b6e7.png" /></kbd></a>
 
 ## This can be previewed here:  
 https://maxsultan.github.io/img-compressor/


### PR DESCRIPTION
A little known secret: If you just use the image alone, it'll link to a higher-res version of the image.

**But**... if you surround with a `<kbd>` and use an `<a>` to link, it looks better and takes the person to the thing. 😉

## Preview

See https://github.com/coolaj86/img-compressor/tree/patch-2

---

## Side Note

Use `Prettier` - your markdown formatting is off and won't work in all parsers